### PR TITLE
Handle partial system data with Promise.allSettled

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
             return;
           }
 
-          const systems = await Promise.all(
+          const settled = await Promise.allSettled(
             presence.map(async (p) => {
               const sysRes = await fetch(
                 `https://elitebgs.app/api/ebgs/v5/systems?name=${encodeURIComponent(p.system_name)}`,
@@ -92,6 +92,10 @@
               return sysData.docs[0];
             }),
           );
+
+          const systems = settled
+            .filter((r) => r.status === "fulfilled" && r.value)
+            .map((r) => r.value);
 
           content.innerHTML = "";
           systems.forEach((sys) => {


### PR DESCRIPTION
## Summary
- use `Promise.allSettled` when loading system data for the overview
- ignore rejected system requests and render only successful ones

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c04f7275f48331af0bf6b83c2b798e