### PR TITLE
Show error details when overview loading fails

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,10 +139,16 @@
               },
             });
           });
-        } catch (err) {
-          console.error(err);
-          content.textContent = "Nepodařilo se načíst data.";
-        }
+          } catch (err) {
+            console.error(err);
+            const details =
+              err?.message || (err?.status ? `HTTP ${err.status}` : "");
+            const hint = " Zkontrolujte název systému nebo síťové připojení.";
+            content.textContent =
+              `Nepodařilo se načíst data${
+                details ? `: ${details}` : ""
+              }.${hint}`;
+          }
       }
 
       overviewBtn.addEventListener("click", loadOverview);


### PR DESCRIPTION
## Summary
- display error message or HTTP status when overview data fails to load
- append hint about checking system name or network connection

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c04f765c6883319b762e457104c9a1