### PR TITLE
Handle multiple system name fields in overview fetch

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,14 +83,20 @@
           }
 
           const systems = await Promise.all(
-            presence.map(async (p) => {
-              const sysRes = await fetch(
-                `https://elitebgs.app/api/ebgs/v5/systems?name=${encodeURIComponent(p.system_name)}`,
-              );
-              if (!sysRes.ok) throw new Error("Chyba API");
-              const sysData = await sysRes.json();
-              return sysData.docs[0];
-            }),
+            presence
+              .map(
+                (p) =>
+                  p.system_name || p.systemName || p.system || p.name,
+              )
+              .filter(Boolean)
+              .map(async (systemName) => {
+                const sysRes = await fetch(
+                  `https://elitebgs.app/api/ebgs/v5/systems?name=${encodeURIComponent(systemName)}`,
+                );
+                if (!sysRes.ok) throw new Error("Chyba API");
+                const sysData = await sysRes.json();
+                return sysData.docs[0];
+              }),
           );
 
           content.innerHTML = "";


### PR DESCRIPTION
## Summary
- Support multiple system identifier keys when fetching system details
- Skip presence entries without a valid system name to avoid failing fetch calls

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c04f79a7608331b29c784cdcf0e0e9