### PR TITLE
Add favorite systems and detail view

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # HIP-76954-DYNASTY
 
 Nástěnka s informacemi o frakci **HIP 76954 DYNASTY**. Otevřete `index.html` a klikněte na tlačítko **Přehled**. Stránka se připojí k [EliteBGS API](https://elitebgs.app/) a zobrazí seznam všech systémů, kde je tato frakce přítomna. Každý systém je zobrazen v tlačítku se jménem a barevně označeným procentem vlivu frakce.
+
+U každého systému je zelené tlačítko **+** pro přidání mezi oblíbené na hlavní stránce. Kliknutím na název systému se otevře nové okno s detailními informacemi z EliteBGS.

--- a/index.html
+++ b/index.html
@@ -47,16 +47,27 @@
       .system-button {
         display: flex;
         align-items: center;
-        justify-content: space-between;
         width: 390px;
         padding: 1rem;
         border: 2px solid #ccc;
         border-radius: 8px;
         background-color: #f9f9f9;
         font-size: 1.1rem;
+        gap: 0.5rem;
+      }
+      .add-btn {
+        width: 24px;
+        height: 24px;
+        background-color: #2ecc71;
+        color: #fff;
+        border: none;
+        border-radius: 4px;
+        cursor: pointer;
+        font-weight: bold;
       }
       .system-name {
         flex-grow: 1;
+        cursor: pointer;
       }
       .inf-circle {
         width: 44px;
@@ -102,6 +113,13 @@
       const content = document.getElementById("content");
 
       let factionPresence = [];
+      let homeSystems = [];
+
+      function addSystemToHome(p) {
+        if (!homeSystems.find((s) => s.system_name === p.system_name)) {
+          homeSystems.push(p);
+        }
+      }
 
       function renderSystems() {
         const sortBy = sortSelect.value;
@@ -118,12 +136,26 @@
         list.className = "system-list";
 
         sorted.forEach((p) => {
-          const btn = document.createElement("button");
-          btn.className = "system-button";
+          const row = document.createElement("div");
+          row.className = "system-button";
+
+          const addBtn = document.createElement("button");
+          addBtn.className = "add-btn";
+          addBtn.textContent = "+";
+          addBtn.addEventListener("click", (e) => {
+            e.stopPropagation();
+            addSystemToHome(p);
+          });
 
           const nameSpan = document.createElement("span");
           nameSpan.className = "system-name";
           nameSpan.textContent = p.system_name;
+          nameSpan.addEventListener("click", () => {
+            window.open(
+              `index.html?system=${encodeURIComponent(p.system_name)}`,
+              "_blank",
+            );
+          });
 
           const inf = Math.round((p.influence || 0) * 100);
           const circle = document.createElement("span");
@@ -133,9 +165,10 @@
           else if (inf <= 50) circle.classList.add("medium");
           else circle.classList.add("high");
 
-          btn.appendChild(nameSpan);
-          btn.appendChild(circle);
-          list.appendChild(btn);
+          row.appendChild(addBtn);
+          row.appendChild(nameSpan);
+          row.appendChild(circle);
+          list.appendChild(row);
         });
 
         content.innerHTML = "";
@@ -165,7 +198,76 @@
       }
 
       function loadHome() {
-        content.innerHTML = "<p>Vítejte na hlavní stránce.</p>";
+        const wrapper = document.createElement("div");
+        const intro = document.createElement("p");
+        intro.textContent = "Vítejte na hlavní stránce.";
+        wrapper.appendChild(intro);
+
+        if (homeSystems.length) {
+          const list = document.createElement("div");
+          list.className = "system-list";
+
+          homeSystems.forEach((p) => {
+            const row = document.createElement("div");
+            row.className = "system-button";
+
+            const nameSpan = document.createElement("span");
+            nameSpan.className = "system-name";
+            nameSpan.textContent = p.system_name;
+            nameSpan.addEventListener("click", () => {
+              window.open(
+                `index.html?system=${encodeURIComponent(p.system_name)}`,
+                "_blank",
+              );
+            });
+
+            const inf = Math.round((p.influence || 0) * 100);
+            const circle = document.createElement("span");
+            circle.className = "inf-circle";
+            circle.textContent = `${inf}%`;
+            if (inf <= 30) circle.classList.add("low");
+            else if (inf <= 50) circle.classList.add("medium");
+            else circle.classList.add("high");
+
+            row.appendChild(nameSpan);
+            row.appendChild(circle);
+            list.appendChild(row);
+          });
+
+          wrapper.appendChild(list);
+        } else {
+          const none = document.createElement("p");
+          none.textContent = "Zatím nejsou vybrány žádné systémy.";
+          wrapper.appendChild(none);
+        }
+
+        content.innerHTML = "";
+        content.appendChild(wrapper);
+      }
+
+      async function loadSystemDetail(name) {
+        content.innerHTML = "<p>Načítání...</p>";
+        try {
+          const res = await fetch(
+            `https://elitebgs.app/api/ebgs/v5/systems?name=${encodeURIComponent(
+              name,
+            )}`,
+          );
+          if (!res.ok) throw new Error("Chyba API");
+          const data = await res.json();
+          const system = data.docs && data.docs[0];
+          if (!system) {
+            content.textContent = "Systém nenalezen.";
+            return;
+          }
+          const pre = document.createElement("pre");
+          pre.textContent = JSON.stringify(system, null, 2);
+          content.innerHTML = "";
+          content.appendChild(pre);
+        } catch (err) {
+          console.error(err);
+          content.textContent = "Nepodařilo se načíst data systému.";
+        }
       }
 
       homeBtn.addEventListener("click", loadHome);
@@ -174,7 +276,13 @@
         if (factionPresence.length) renderSystems();
       });
 
-      loadHome();
+      const params = new URLSearchParams(window.location.search);
+      const systemParam = params.get("system");
+      if (systemParam) {
+        loadSystemDetail(systemParam);
+      } else {
+        loadHome();
+      }
     </script>
     </body>
 </html>


### PR DESCRIPTION
## Summary
- allow adding systems to a favorite list on the home page
- show green plus icons and clickable system names in overview
- support opening a system detail page with information from EliteBGS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0580c71048331af2f2ecf7b485d4b