### PR TITLE
Use table layout for overview with dark theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,8 @@
       body {
         margin: 0;
         font-family: Arial, sans-serif;
+        background-color: #000;
+        color: #fff;
       }
       header {
         background-color: #333;
@@ -24,6 +26,7 @@
         width: 352px; /* reduced by 20% */
         background-color: #f4f4f4;
         padding: 1rem;
+        color: #000;
       }
       main {
         flex-grow: 1;
@@ -48,17 +51,27 @@
         transform: scale(0.95);
       }
 
-      /* Overview list */
+      /* Overview table */
+      .system-table {
+        border: 2px solid #ff00ff;
+        border-collapse: collapse;
+        margin: 1rem auto;
+        background-color: #000;
+      }
+      .system-table th,
+      .system-table td {
+        padding: 0.5rem;
+        border: 1px solid #ffff00;
+      }
+      #sortSelect {
+        color: #000;
+      }
       .system-list {
         display: grid;
         grid-template-columns: repeat(3, 390px);
         gap: 1rem;
         justify-content: center;
         margin: 0 auto;
-      }
-      #sortSelect {
-        display: block;
-        margin: 1rem auto;
       }
       .system-button {
         display: flex;
@@ -70,6 +83,7 @@
         background-color: #f9f9f9;
         font-size: 1.1rem;
         gap: 0.5rem;
+        color: #000;
       }
       .add-btn {
         width: 24px;
@@ -151,11 +165,6 @@
     <header>
       <h1>Impérium HIP 76954 DYNASTY</h1>
     </header>
-    <select id="sortSelect">
-      <option value="population">Populace</option>
-      <option value="percentage">Procenta</option>
-      <option value="influence">Vliv</option>
-    </select>
     <div class="layout">
       <aside>
         <button id="homeBtn" class="nav-button">Hlavní strana</button>
@@ -166,8 +175,8 @@
     <script>
       const overviewBtn = document.getElementById("overviewBtn");
       const homeBtn = document.getElementById("homeBtn");
-      const sortSelect = document.getElementById("sortSelect");
       const content = document.getElementById("content");
+      let sortSelect;
 
       let factionPresence = [];
       let homeSystems = [];
@@ -190,7 +199,7 @@
       }
 
       function renderSystems() {
-        const sortBy = sortSelect.value;
+        const sortBy = sortSelect ? sortSelect.value : "population";
         const sorted = [...factionPresence];
         if (sortBy === "population") {
           sorted.sort(
@@ -200,13 +209,29 @@
           sorted.sort((a, b) => (b.influence || 0) - (a.influence || 0));
         }
 
-        const list = document.createElement("div");
-        list.className = "system-list";
+        const tbl = document.createElement("table");
+        tbl.className = "system-table";
+
+        const headerRow = document.createElement("tr");
+        const headerCell = document.createElement("th");
+        headerCell.colSpan = 3;
+        sortSelect = document.createElement("select");
+        sortSelect.id = "sortSelect";
+        sortSelect.innerHTML = `
+          <option value="population">Populace</option>
+          <option value="percentage">Procenta</option>
+          <option value="influence">Vliv</option>
+        `;
+        sortSelect.value = sortBy;
+        sortSelect.addEventListener("change", renderSystems);
+        headerCell.appendChild(sortSelect);
+        headerRow.appendChild(headerCell);
+        tbl.appendChild(headerRow);
 
         sorted.forEach((p) => {
-          const row = document.createElement("div");
-          row.className = "system-button";
+          const row = document.createElement("tr");
 
+          const addCell = document.createElement("td");
           const addBtn = document.createElement("button");
           addBtn.className = "add-btn";
           addBtn.textContent = "+";
@@ -214,7 +239,9 @@
             e.stopPropagation();
             addSystemToHome(p);
           });
+          addCell.appendChild(addBtn);
 
+          const nameCell = document.createElement("td");
           const nameSpan = document.createElement("span");
           nameSpan.className = "system-name";
           nameSpan.textContent = p.system_name;
@@ -224,7 +251,9 @@
               "_blank",
             );
           });
+          nameCell.appendChild(nameSpan);
 
+          const infCell = document.createElement("td");
           const inf = Math.round((p.influence || 0) * 100);
           const circle = document.createElement("span");
           circle.className = "inf-circle";
@@ -232,15 +261,16 @@
           if (inf <= 30) circle.classList.add("low");
           else if (inf <= 50) circle.classList.add("medium");
           else circle.classList.add("high");
+          infCell.appendChild(circle);
 
-          row.appendChild(addBtn);
-          row.appendChild(nameSpan);
-          row.appendChild(circle);
-          list.appendChild(row);
+          row.appendChild(addCell);
+          row.appendChild(nameCell);
+          row.appendChild(infCell);
+          tbl.appendChild(row);
         });
 
         content.innerHTML = "";
-        content.appendChild(list);
+        content.appendChild(tbl);
       }
 
       async function loadOverview() {
@@ -451,9 +481,6 @@
 
       addAnimatedClick(homeBtn, loadHome);
       addAnimatedClick(overviewBtn, loadOverview);
-      sortSelect.addEventListener("change", () => {
-        if (factionPresence.length) renderSystems();
-      });
 
       const params = new URLSearchParams(window.location.search);
       const systemParam = params.get("system");


### PR DESCRIPTION
## Summary
- Present overview systems in a single table with in-table sorting dropdown
- Apply black page background, pink table border, and yellow system borders

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0762652688331a467280fee6a64e0