### PR TITLE
Add removable home systems and larger display

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,6 +99,25 @@
         gap: 0.5rem;
         color: #000;
       }
+      .home-system-list {
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+      }
+      .home-system {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        width: 100%;
+        padding: 2rem;
+        border: 2px solid #ccc;
+        border-radius: 8px;
+        background-color: #f9f9f9;
+        font-size: 2.2rem;
+        color: #000;
+        box-sizing: border-box;
+      }
       .add-btn {
         width: 24px;
         height: 24px;
@@ -118,6 +137,27 @@
         box-shadow: 0 0 4px #ff00ff;
       }
       .add-btn.clicked {
+        transform: scale(0.95);
+      }
+      .remove-btn {
+        width: 24px;
+        height: 24px;
+        background-color: #e74c3c;
+        color: #fff;
+        border: 2px solid transparent;
+        border-radius: 4px;
+        cursor: pointer;
+        font-weight: bold;
+        transition:
+          transform 0.1s,
+          box-shadow 0.1s,
+          border-color 0.1s;
+      }
+      .remove-btn:hover {
+        border-color: #ff00ff;
+        box-shadow: 0 0 4px #ff00ff;
+      }
+      .remove-btn.clicked {
         transform: scale(0.95);
       }
       .system-name {
@@ -142,6 +182,11 @@
       }
       .inf-circle.high {
         background-color: #2ecc71;
+      }
+      .home-system .inf-circle {
+        width: 88px;
+        height: 88px;
+        font-size: 1.5rem;
       }
 
       #stats {
@@ -199,6 +244,7 @@
       let homeSystems = [];
       let lastSortBy = "name";
       let sortAscending = true;
+      let currentView = "home";
 
       function addAnimatedClick(el, handler) {
         el.addEventListener("click", (e) => {
@@ -214,7 +260,13 @@
       function addSystemToHome(p) {
         if (!homeSystems.find((s) => s.system_name === p.system_name)) {
           homeSystems.push(p);
+          if (currentView === "home") loadHome();
         }
+      }
+
+      function removeSystemFromHome(name) {
+        homeSystems = homeSystems.filter((s) => s.system_name !== name);
+        if (currentView === "home") loadHome();
       }
 
       function stripEnumPrefix(value) {
@@ -275,14 +327,20 @@
           const row = document.createElement("tr");
 
           const addCell = document.createElement("td");
-          const addBtn = document.createElement("button");
-          addBtn.className = "add-btn";
-          addBtn.textContent = "+";
-          addAnimatedClick(addBtn, (e) => {
+          const isHome = homeSystems.some((s) => s.system_name === p.system_name);
+          const btn = document.createElement("button");
+          btn.className = isHome ? "remove-btn" : "add-btn";
+          btn.textContent = isHome ? "-" : "+";
+          addAnimatedClick(btn, (e) => {
             e.stopPropagation();
-            addSystemToHome(p);
+            if (isHome) {
+              removeSystemFromHome(p.system_name);
+            } else {
+              addSystemToHome(p);
+            }
+            renderSystems();
           });
-          addCell.appendChild(addBtn);
+          addCell.appendChild(btn);
 
           const nameCell = document.createElement("td");
           const nameSpan = document.createElement("span");
@@ -314,6 +372,7 @@
       }
 
       async function loadOverview() {
+        currentView = "overview";
         content.innerHTML = "<p>Načítání...</p>";
         try {
           const res = await fetch(
@@ -397,23 +456,19 @@
       }
 
       function loadHome() {
+        currentView = "home";
         const wrapper = document.createElement("div");
         const intro = document.createElement("p");
         intro.textContent = "Vítejte na hlavní stránce.";
         wrapper.appendChild(intro);
 
-        const statsDiv = document.createElement("div");
-        statsDiv.id = "stats";
-        wrapper.appendChild(statsDiv);
-        loadFactionStats(statsDiv);
-
         if (homeSystems.length) {
           const list = document.createElement("div");
-          list.className = "system-list";
+          list.className = "home-system-list";
 
           homeSystems.forEach((p) => {
             const row = document.createElement("div");
-            row.className = "system-button";
+            row.className = "home-system";
 
             const nameSpan = document.createElement("span");
             nameSpan.className = "system-name";
@@ -441,6 +496,11 @@
           none.textContent = "Zatím nejsou vybrány žádné systémy.";
           wrapper.appendChild(none);
         }
+
+        const statsDiv = document.createElement("div");
+        statsDiv.id = "stats";
+        wrapper.appendChild(statsDiv);
+        loadFactionStats(statsDiv);
 
         content.innerHTML = "";
         content.appendChild(wrapper);


### PR DESCRIPTION
## Summary
- Allow systems in the overview to toggle between add and remove with a red minus button
- Show selected systems above the stats on the home page with full-width, enlarged cards

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c07e9a79e8833186f7e903986f960c