### PR TITLE
Ensure home table spans full width

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
         padding: 1rem;
         display: flex;
         flex-direction: column;
-        align-items: center;
+        align-items: stretch;
       }
       .nav-button {
         width: 100%;
@@ -469,6 +469,7 @@
       function loadHome() {
         currentView = "home";
         const wrapper = document.createElement("div");
+        wrapper.style.width = "100%";
         const intro = document.createElement("p");
         intro.textContent = "Vítejte na hlavní stránce.";
         wrapper.appendChild(intro);


### PR DESCRIPTION
## Summary
- Use `align-items: stretch` for `<main>` so children can fill width
- Set home view wrapper to `width: 100%` to let the home table span available space

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c08b2c717083319589891870b56422