### PR TITLE
Start support at zero and align home column widths

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,6 +116,12 @@
       .home-table th {
         background-color: #000;
       }
+      .home-table th:nth-child(3),
+      .home-table td:nth-child(3),
+      .home-table th:nth-child(6),
+      .home-table td:nth-child(6) {
+        width: 150px;
+      }
       .priority-star {
         color: #ffff00;
         font-size: 1.5rem;
@@ -511,7 +517,7 @@
             progContainer.className = "progress-container";
             const progBar = document.createElement("div");
             progBar.className = "progress-bar";
-            progBar.style.width = `${inf}%`;
+            progBar.style.width = "0%";
             progContainer.appendChild(progBar);
             supportTd.appendChild(progContainer);
 


### PR DESCRIPTION
## Summary
- Initialize support progress bars at zero instead of influence percentage
- Give 'Cíle' and 'Co dělat' columns identical width for a consistent layout

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c08d66a16c8331ac08dc6c5ac1cfe9