### PR TITLE
Add sample local data for system details

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,10 @@
 Nástěnka s informacemi o frakci **HIP 76954 DYNASTY**. Otevřete `index.html` a klikněte na tlačítko **Přehled**. Stránka se připojí k [EliteBGS API](https://elitebgs.app/) a zobrazí seznam všech systémů, kde je tato frakce přítomna. Každý systém je zobrazen v tlačítku se jménem a barevně označeným procentem vlivu frakce.
 
 U každého systému je zelené tlačítko **+** pro přidání mezi oblíbené na hlavní stránce. Kliknutím na název systému se zobrazí detailní informace ve stejném okně.
+
+## Lokální data
+
+Pro demonstraci je v repozitáři přiložena minimální sada souborů `*.json` (např. `systemsPopulated.json`, `stations.json` atd.).
+Pokud jsou tyto soubory uložené vedle `index.html`, stránka načte a zobrazí doplňující informace v sekci *Lokální data*.
+
+Pro reálné použití nahraďte tyto ukázkové soubory aktuálními datovými dumpy z [EDSM](https://www.edsm.net/) nebo jiného zdroje.

--- a/bodies7days.json
+++ b/bodies7days.json
@@ -1,0 +1,1 @@
+[{"name":"HIP 76954 A 1","system_name":"HIP 76954"}]

--- a/codex.json
+++ b/codex.json
@@ -1,0 +1,1 @@
+[{"name":"Anomaly","system_name":"HIP 76954"}]

--- a/index.html
+++ b/index.html
@@ -292,7 +292,7 @@
       let codexLocal = [];
       let powerPlayLocal = [];
 
-      async function loadGzJson(url) {
+      async function loadJson(url) {
         const res = await fetch(url);
         if (!res.ok) throw new Error("Nelze načíst " + url);
         const buffer = await res.arrayBuffer();
@@ -309,11 +309,11 @@
         if (localDataLoaded) return;
         try {
           const [systems, stations, codex, bodies, powerPlay] = await Promise.all([
-            loadGzJson("systemsPopulated.json.gz"),
-            loadGzJson("stations.json.gz"),
-            loadGzJson("codex.json.gz"),
-            loadGzJson("bodies7days.json.gz"),
-            loadGzJson("powerPlay.json.gz"),
+            loadJson("systemsPopulated.json"),
+            loadJson("stations.json"),
+            loadJson("codex.json"),
+            loadJson("bodies7days.json"),
+            loadJson("powerPlay.json"),
           ]);
           systemsLocal = systems;
           stationsLocal = stations;

--- a/powerPlay.json
+++ b/powerPlay.json
@@ -1,0 +1,1 @@
+[{"power":"A. Lavigny-Duval","state":"Control","system_name":"HIP 76954"}]

--- a/stations.json
+++ b/stations.json
@@ -1,0 +1,1 @@
+[{"name":"Fortune Base","system_name":"HIP 76954"}]

--- a/systemsPopulated.json
+++ b/systemsPopulated.json
@@ -1,0 +1,1 @@
+[{"name":"HIP 76954","allegiance":"Empire","government":"Patronage","economy":"Industrial","population":4500000}]


### PR DESCRIPTION
## Summary
- replace gzipped datasets with plain `.json` files to avoid binary file warnings
- update loader to fetch new JSON filenames
- document the `.json` samples for local data

## Testing
- `jq '.' systemsPopulated.json stations.json codex.json bodies7days.json powerPlay.json`


------
https://chatgpt.com/codex/tasks/task_e_68c1a50379148331a3a86e1c3d798872