### PR TITLE
Display API error details in overview

### DIFF
--- a/index.html
+++ b/index.html
@@ -782,7 +782,8 @@
           const res = await fetch(
             "https://elitebgs.app/api/ebgs/v5/factions?name=HIP%2076954%20DYNASTY",
           );
-          if (!res.ok) throw new Error("Chyba API");
+          if (!res.ok)
+            throw new Error(`API vrací ${res.status} ${res.statusText}`);
           const data = await res.json();
           const faction = data.docs && data.docs[0];
           if (!faction || !Array.isArray(faction.faction_presence)) {
@@ -802,8 +803,8 @@
           content.innerHTML = "";
           content.appendChild(wrapper);
         } catch (err) {
-          console.error(err);
-          content.textContent = "Nepodařilo se načíst data.";
+          console.error("Chyba při načítání přehledu:", err.message, err);
+          content.textContent = `Nepodařilo se načíst data: ${err.message}`;
         }
       }
 


### PR DESCRIPTION
## Summary
- Log loadOverview API failures with status and text
- Show the API error message to the user for better diagnostics

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c591ab2370833194bfd3642625343c