### PR TITLE
Validate API response in loadOverview

### DIFF
--- a/index.html
+++ b/index.html
@@ -785,7 +785,15 @@
           if (!res.ok)
             throw new Error(`API vrací ${res.status} ${res.statusText}`);
           const data = await res.json();
-          const faction = data.docs && data.docs[0];
+          if (
+            !data ||
+            typeof data !== "object" ||
+            !Array.isArray(data.docs)
+          ) {
+            content.textContent = "Neočekávaný formát odpovědi API.";
+            return;
+          }
+          const faction = data.docs[0];
           if (!faction || !Array.isArray(faction.faction_presence)) {
             content.textContent = "Neočekávaný formát odpovědi API.";
             return;


### PR DESCRIPTION
## Summary
- Ensure API response contains a docs array before accessing the first element

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5942058f48331b311802782ede592