### PR TITLE
Use Firebase Authentication for user accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Pokud API odmítá CORS pro váš původ, zvažte hostování přes HTTPS nebo p
 
 ## Přihlášení
 
-Před zobrazením stránky je vyžadováno přihlášení pomocí [Firebase Authentication](https://firebase.google.com/). Konfigurace projektu pro `hip-75964-dynasty` je již vložena v souboru `index.html`. Nově registrovaní uživatelé se ukládají do kolekce `users` ve službě Firestore.
+Před zobrazením stránky je vyžadováno přihlášení pomocí [Firebase Authentication](https://firebase.google.com/). Konfigurace projektu pro `hip-75964-dynasty` je již vložena v souboru `index.html`. Nově registrovaní uživatelé jsou spravováni výhradně pomocí Firebase Authentication; žádná data se neukládají do Firestore.
 
 ## Lokální data
 

--- a/index.html
+++ b/index.html
@@ -324,11 +324,6 @@
         const email = document.getElementById("email").value;
         const password = document.getElementById("password").value;
         createUserWithEmailAndPassword(auth, email, password)
-          .then((userCredential) =>
-            setDoc(doc(db, "users", userCredential.user.uid), {
-              email: userCredential.user.email,
-            }),
-          )
           .then(() => {
             loginScreen.style.display = "none";
             appDiv.style.display = "block";


### PR DESCRIPTION
## Summary
- Handle user registration solely with Firebase Authentication
- Clarify in docs that no user data is stored in Firestore

## Testing
- `npm test` *(fails: Could not read package.json)*
- `(cd functions && npm test)`

------
https://chatgpt.com/codex/tasks/task_e_68c594ae0d9083318f87dd57ed1a868d